### PR TITLE
Fix materialized view name

### DIFF
--- a/query/adm_details.sql
+++ b/query/adm_details.sql
@@ -1,5 +1,5 @@
 DROP MATERIALIZED VIEW IF EXISTS adm_details CASCADE;
-CREATE MATERIALIZED VIEW pivoted_lab as
+CREATE MATERIALIZED VIEW adm_details as
 (
     select p.subject_id, p.gender, p.dob, p.dod, hadm_id, admittime, dischtime, admission_type, insurance, marital_status, ethnicity, hospital_expire_flag, has_chartevents_data
     from admissions adm


### PR DESCRIPTION
The materialized view name for [adm_details](https://github.com/onlyzdd/clinical-fusion/blob/09e1806b85a38febfd3ccdd72fb3fb9ca3db70d4/query/adm_details.sql#L2) SQL file was named as `pivotal_lab` but instead, it should have been `adm_details`.

This PR aims to fix this bug.